### PR TITLE
Fix setup: add gifs and pngs to package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,8 @@ setup(
 
     install_requires=install_requires,
 
+    include_package_data=True,
+
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Programming Language :: Python',


### PR DESCRIPTION
The build wasn't including data files such as gifs and pngs. This caused the pdf generation to fail with many errors such as `FileNotFoundError ... /correios-pdf-generation-service/lib/python3.5/site-packages/correios/data/standard.gif'`.

This PR fix the package build to include these files.